### PR TITLE
version/0.3.0 -> master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,6 +181,7 @@ python/railroaded/tmp/
 python/tests/septa_cache.json
 python/tests/septa_cache.pkl
 python/tests/patco_cache.json
+python/tests/patco_shapes_cache.json
 node_modules
 
 # Useful snippets

--- a/CODEBASE.md
+++ b/CODEBASE.md
@@ -1,12 +1,12 @@
 # railroaded — Codebase Reference
 
-> Last updated: 2026-04-08 | Branch: version/0.2.1 | Version: **0.2.1**
+> Last updated: 2026-04-09 | Branch: version/0.3.0 | Version: **0.3.0**
 
 ---
 
 ## What This Project Does
 
-`railroaded` is a dual-language (Python + TypeScript) library for fetching, parsing, and querying **GTFS (General Transit Feed Specification)** data. It converts verbose GTFS CSV datasets into a minified **mGTFS JSON** format for efficient local querying of transit information: agencies, routes, stops, trips, and schedules.
+`railroaded` is a dual-language (Python + TypeScript) library for fetching, parsing, and querying **GTFS (General Transit Feed Specification)** data. It converts verbose GTFS CSV datasets into a minified **mGTFS JSON** format for efficient local querying of transit information: agencies, routes, stops, trips, schedules, and (optionally) shape polyline geometry.
 
 **Primary use case:** Download a GTFS ZIP (or load a local file), parse it into structured models, then query it — e.g., "what trips run on this route today?" or "what stops connect route A to route B?"
 
@@ -49,6 +49,8 @@ GTFS (entry-point facade)
 | `DateRange` | `calendar.txt` | One weekly-schedule entry with inclusive date bounds |
 | `Calendar` | `calendar.txt` | Recurring day-of-week record (parsed into `DateRange`) |
 | `CalendarDate` | `calendar_dates.txt` | One-off schedule additions/exceptions |
+| `ShapePoint` | `shapes.txt` | One point in a shape polyline (lat, lon, sequence) |
+| `Shape` | `shapes.txt` | Ordered polyline of `ShapePoint` records for a single shape_id |
 
 ### Tables
 
@@ -59,12 +61,13 @@ GTFS (entry-point facade)
 | `Stops` | `dict[str, Stop]` | `ids`, `stops`, `__getitem__` |
 | `Trips` | `dict[str, Trip]` | `ids`, `trips`, filter by route/stop/date/time |
 | `Schedules` | `dict[str, Schedule]` | `service_ids`, `on_date()`, `__getitem__` |
+| `Shapes` | `dict[str, Shape]` | `ids`, `shapes`, `__getitem__`; opt-in via `shapes=True` on `GTFS.read()` |
 
 ### Entry Point: `GTFS` class
 
 | Method | Signature | Purpose |
 |--------|-----------|---------|
-| `read` | `(name, gtfs_path?, gtfs_sub?, gtfs_uri?, mgtfs_path?)` | Download/extract/parse GTFS or load mGTFS JSON cache |
+| `read` | `(name, gtfs_path?, gtfs_sub?, gtfs_uri?, mgtfs_path?, shapes=False)` | Download/extract/parse GTFS or load mGTFS JSON cache; `shapes=True` loads shapes.txt polyline geometry |
 | `save` | `(gtfs, mgtfs_path)` | Serialise to mGTFS JSON file |
 | `on_date` | `(date)` | Filter trips active on a given calendar date |
 | `today` | `()` | Shorthand for `on_date(date.today())` |
@@ -97,22 +100,27 @@ railroaded/
 │   │   │   ├── feed.py              # Feed (optional feed_info.txt)
 │   │   │   ├── route.py             # Route + TransitType enum
 │   │   │   ├── schedule.py          # Schedule: active() + date-range aggregation
+│   │   │   ├── shape.py             # Shape: ordered polyline of ShapePoints
+│   │   │   ├── shape_point.py       # ShapePoint: one lat/lon/sequence point
 │   │   │   ├── stop.py              # Stop + LocationType enum
 │   │   │   ├── stop_continuity.py   # StopContinuity enum
-│   │   │   ├── stop_time.py         # StopTime + GTFS time parsing (hours ≥ 24)
-│   │   │   ├── timetable.py         # Timetable: ordered stop→StopTime map
+│   │   │   ├── stop_time.py         # StopTime + GTFS time parsing (hours >= 24)
+│   │   │   ├── timetable.py         # Timetable: ordered stop->StopTime map
 │   │   │   └── trip.py              # Trip + BikesAllowed enum
 │   │   └── tables/
 │   │       ├── __init__.py
 │   │       ├── agencies.py
 │   │       ├── routes.py
 │   │       ├── schedules.py         # Handles missing calendar.txt / calendar_dates.txt
+│   │       ├── shapes.py            # Shapes: groups ShapePoints by shape_id; from_gtfs()
 │   │       ├── stops.py
 │   │       └── trips.py
 │   └── tests/
 │       ├── conftest.py              # Session-scoped SEPTA fixture (downloads + mGTFS cache)
 │       ├── septa_cache.json         # mGTFS cache (gitignored, generated on first run)
-│       └── test_gtfs.py             # 31 integration tests
+│       ├── test_gtfs.py             # 31 integration tests
+│       ├── test_patco.py            # 16 PATCO integration tests
+│       └── test_shapes.py           # 14 shapes.txt tests (opt-in, serialisation, backward compat)
 ├── typescript/
 │   └── src/
 │       ├── gtfs.ts                  # GTFS facade class
@@ -129,6 +137,28 @@ railroaded/
 ├── package.json                     # version 0.2.1
 └── tsconfig.json
 ```
+
+---
+
+## Opt-in shapes.txt support
+
+`GTFS.read(..., shapes=True)` loads `shapes.txt` (polyline geometry for each trip's geographic path) into a `Shapes` table. When `shapes=False` (default), the table is empty, keeping memory and mGTFS cache size minimal.
+
+```python
+# Without shapes (default — lightweight)
+gtfs = rr.GTFS.read(name='SEPTA', gtfs_uri=uri, mgtfs_path=cache)
+
+# With shapes (for map rendering)
+gtfs = rr.GTFS.read(name='SEPTA', gtfs_uri=uri, mgtfs_path=cache, shapes=True)
+
+# Access shape geometry for a trip
+shape = gtfs.shapes[trip.shape_id]
+if shape:
+    for pt in shape.points:
+        print(pt.lat, pt.lon, pt.sequence)
+```
+
+The mGTFS cache includes shapes data only when originally saved with shapes loaded. Existing caches without a `shapes` key load with an empty table (backward compatible). Feeds that lack `shapes.txt` also produce an empty table regardless of the flag.
 
 ---
 
@@ -235,3 +265,4 @@ All issues from the initial code review were resolved in 0.2.1. A further seared
 - TypeScript implementation has no test suite
 - Some non-null assertions (`!`) remain in TypeScript tables/util (low risk — data validated upstream)
 - `Timetable.between(start: time, end: time)` and `Trip.between(...)` do not handle overnight trips correctly; use `GTFS.between(datetime, datetime)` for all production queries
+- Shapes support is Python-only; TypeScript implementation does not yet parse `shapes.txt`

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "railroaded"
-version = "0.2.1"
+version = "0.3.0"
 description = ""
 authors = ["Benj Wiswell <benjwiswell@gmail.com>"]
 

--- a/python/railroaded/__init__.py
+++ b/python/railroaded/__init__.py
@@ -4,7 +4,7 @@ import shutil
 from .gtfs import GTFS
 
 
-__version__ = '0.2.1'
+__version__ = '0.3.0'
 
 
 _TMP = os.path.join(os.path.realpath(os.path.dirname(__file__)), 'tmp')

--- a/python/railroaded/gtfs.py
+++ b/python/railroaded/gtfs.py
@@ -15,6 +15,7 @@ from .tables import (
     Agencies,
     Routes,
     Schedules,
+    Shapes,
     Stops,
     Trips
 )
@@ -63,6 +64,8 @@ class GTFS(s.Seared):
     '''a `Stops` table mapping `str` IDs to `Stop` records'''
     trips: Trips = s.T(schema=Trips.SCHEMA)
     '''a `Trips` table mapping `str` IDs to `Trip` records'''
+    shapes: Shapes = s.T(schema=Shapes.SCHEMA)
+    '''a `Shapes` table mapping `str` IDs to `Shape` records (opt-in via shapes=True)'''
 
 
     ### CLASS METHODS ###
@@ -73,7 +76,8 @@ class GTFS(s.Seared):
                 gtfs_path: Optional[str] = None,
                 gtfs_sub: Optional[str] = None,
                 gtfs_uri: Optional[str] = None,
-                mgtfs_path: Optional[str] = None
+                mgtfs_path: Optional[str] = None,
+                shapes: bool = False
             ) -> GTFS:
         '''
         Returns a `GTFS` object containing minified GTFS data read from local
@@ -82,13 +86,13 @@ class GTFS(s.Seared):
         If provided, `mgtfs_path` is checked first for a mGTFS dataset. If it
         exists, the `GTFS` object is created from it and returned; otherwise,
         `read` falls back to one of the following:
-        
+
         - reading a unzipped local GTFS dataset at `gtfs_path`
         - fetching a zipped remote GTFS dataset at `gtfs_uri` with an optional \
             `gtfs_sub` for nested GTFS datasets
 
-        If `mgtfs_path` was specified but `read` fell back to a different 
-        method, the newly parsed mGTFS will be written to `mgtfs_path` to 
+        If `mgtfs_path` was specified but `read` fell back to a different
+        method, the newly parsed mGTFS will be written to `mgtfs_path` to
         improve performance on subsequent reads.
 
         Parameters:
@@ -102,7 +106,11 @@ class GTFS(s.Seared):
                 the URI to use when fetching a remote GTFS dataset
             mgtfs_path (Optional[str]):
                 the path to a local mGTFS dataset
-        
+            shapes (bool):
+                if `True`, load `shapes.txt` polyline geometry; if `False`
+                (default), the `shapes` table is left empty to reduce memory
+                and cache size
+
         Returns:
             gtfs (GTFS):
                 a `GTFS` object containing the minified GTFS dataset
@@ -135,13 +143,14 @@ class GTFS(s.Seared):
             path = gtfs_path
 
         g = GTFS(
-            name=name, 
+            name=name,
             feed=Feed.from_gtfs(path),
-            agencies=Agencies.from_gtfs(path), 
-            routes=Routes.from_gtfs(path), 
+            agencies=Agencies.from_gtfs(path),
+            routes=Routes.from_gtfs(path),
             schedules=Schedules.from_gtfs(path),
             stops=Stops.from_gtfs(path),
-            trips=Trips.from_gtfs(path)
+            trips=Trips.from_gtfs(path),
+            shapes=Shapes.from_gtfs(path) if shapes else Shapes({}),
         )
 
         if not gtfs_path: shutil.rmtree(TMP)
@@ -175,7 +184,8 @@ class GTFS(s.Seared):
             self.routes,
             self.schedules,
             self.stops,
-            trips
+            trips,
+            self.shapes,
         )
     
     def between (self, start: datetime, end: datetime) -> GTFS:

--- a/python/railroaded/models/__init__.py
+++ b/python/railroaded/models/__init__.py
@@ -4,6 +4,8 @@ from .calendar_date import CalendarDate
 from .feed import Feed
 from .route import Route
 from .schedule import Schedule
+from .shape import Shape
+from .shape_point import ShapePoint
 from .stop import Stop
 from .stop_time import StopTime
 from .timetable import Timetable

--- a/python/railroaded/models/shape.py
+++ b/python/railroaded/models/shape.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import seared as s
+
+from .shape_point import ShapePoint
+
+
+@s.seared
+class Shape(s.Seared):
+    '''
+    A GTFS dataclass model grouping all ``ShapePoint`` records for a single
+    shape into an ordered polyline.
+
+    Attributes:
+        id (str):
+            the unique ID of the shape
+        points (list[ShapePoint]):
+            the ordered list of shape points (sorted by sequence)
+    '''
+
+    ### ATTRIBUTES ###
+    id: str = s.Str(data_key='shape_id', required=True)
+    '''the unique ID of the shape'''
+    points: list[ShapePoint] = s.T(
+        schema=ShapePoint.SCHEMA,
+        many=True,
+        required=True,
+    )
+    '''the ordered list of shape points (sorted by sequence)'''

--- a/python/railroaded/models/shape_point.py
+++ b/python/railroaded/models/shape_point.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import Optional
+
+import seared as s
+
+
+@s.seared
+class ShapePoint(s.Seared):
+    '''
+    A GTFS dataclass model for records found in ``shapes.txt``. Identifies a
+    single point in the polyline geometry of a trip shape.
+
+    Attributes:
+        shape_id (str):
+            the unique ID of the shape this point belongs to
+        lat (float):
+            the latitude of the shape point
+        lon (float):
+            the longitude of the shape point
+        sequence (int):
+            the sequence order of this point within its shape
+        dist_traveled (Optional[float]):
+            the distance traveled along the shape from its first point
+    '''
+
+    ### ATTRIBUTES ###
+    shape_id: str = s.Str(required=True)
+    '''the unique ID of the shape this point belongs to'''
+    lat: float = s.Float(data_key='shape_pt_lat', required=True)
+    '''the latitude of the shape point'''
+    lon: float = s.Float(data_key='shape_pt_lon', required=True)
+    '''the longitude of the shape point'''
+    sequence: int = s.Int(data_key='shape_pt_sequence', required=True)
+    '''the sequence order of this point within its shape'''
+    dist_traveled: Optional[float] = s.Float(data_key='shape_dist_traveled')
+    '''the distance traveled along the shape from its first point'''

--- a/python/railroaded/tables/__init__.py
+++ b/python/railroaded/tables/__init__.py
@@ -1,5 +1,6 @@
 from .agencies import Agencies
 from .routes import Routes
 from .schedules import Schedules
+from .shapes import Shapes
 from .trips import Trips
 from .stops import Stops

--- a/python/railroaded/tables/shapes.py
+++ b/python/railroaded/tables/shapes.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+import seared as s
+
+from ..models import Shape, ShapePoint
+from ..util import load_list
+
+
+@s.seared
+class Shapes(s.Seared):
+    '''
+    Serializable dataclass table mapping ``str`` IDs to ``Shape`` records.
+
+    Each ``Shape`` contains an ordered polyline of ``ShapePoint`` records
+    representing the geographic path of a trip.
+
+    Attributes:
+        data (dict[str, Shape]):
+            a ``dict`` mapping ``str`` shape IDs to ``Shape`` records
+        ids (list[str]):
+            a ``list`` of all ``str`` shape IDs
+        shapes (list[Shape]):
+            a ``list`` of all ``Shape`` records
+    '''
+
+    ### ATTRIBUTES ###
+    data: dict[str, Shape] = s.T(
+        schema=Shape.SCHEMA,
+        keyed=True,
+        required=True,
+    )
+    '''a ``dict`` mapping ``str`` shape IDs to ``Shape`` records'''
+
+
+    ### CLASS METHODS ###
+    @classmethod
+    def from_gtfs(cls, path: str) -> Shapes:
+        '''
+        Returns a ``Shapes`` table populated from the GTFS data at ``path``.
+
+        Reads ``shapes.txt``, groups points by ``shape_id``, sorts each group
+        by ``shape_pt_sequence``, and wraps them in ``Shape`` objects.
+
+        If ``shapes.txt`` is absent, returns an empty table.
+
+        Parameters:
+            path (str):
+                the path to the GTFS dataset
+
+        Returns:
+            shapes (Shapes):
+                a ``Shapes`` table populated from the GTFS data at ``path``
+        '''
+        points: list[ShapePoint] = load_list(
+            os.path.join(path, 'shapes.txt'),
+            ShapePoint.SCHEMA,
+            int_cols=['shape_pt_sequence'],
+            float_cols=['shape_pt_lat', 'shape_pt_lon', 'shape_dist_traveled'],
+            required=False,
+        )
+
+        by_id: dict[str, list[ShapePoint]] = {}
+        for pt in points:
+            by_id.setdefault(pt.shape_id, []).append(pt)
+
+        return Shapes({
+            sid: Shape(
+                id=sid,
+                points=sorted(pts, key=lambda p: p.sequence),
+            )
+            for sid, pts in by_id.items()
+        })
+
+
+    ### PROPERTIES ###
+    @property
+    def ids(self) -> list[str]:
+        '''a ``list`` of all ``str`` shape IDs in the ``Shapes`` table'''
+        return list(self.data.keys())
+
+    @property
+    def shapes(self) -> list[Shape]:
+        '''a ``list`` of all ``Shape`` records in the ``Shapes`` table'''
+        return list(self.data.values())
+
+
+    ### MAGIC METHODS ###
+    def __getitem__(self, id: str) -> Optional[Shape]:
+        '''
+        Returns the ``Shape`` record associated with ``id`` if it exists,
+        otherwise returns ``None``.
+
+        Parameters:
+            id (str):
+                the ``str`` id associated with the ``Shape`` record
+
+        Returns:
+            record (Optional[Shape]):
+                the ``Shape`` record associated with ``id`` if it exists,
+                otherwise ``None``
+        '''
+        return self.data.get(id, None)

--- a/python/tests/test_gtfs.py
+++ b/python/tests/test_gtfs.py
@@ -76,7 +76,7 @@ class TestLoad:
         assert len(septa.schedules.service_ids) > 0
 
     def test_version(self) -> None:
-        assert rr.__version__ == '0.2.1'
+        assert rr.__version__ == '0.3.0'
 
 
 # ===========================================================================

--- a/python/tests/test_shapes.py
+++ b/python/tests/test_shapes.py
@@ -1,0 +1,161 @@
+"""
+Tests for the optional shapes.txt loading in railroaded.
+
+Tests verify:
+- shapes=False (default) produces an empty Shapes table
+- shapes=True loads and serializes shape geometry
+- Feeds without shapes.txt produce an empty table regardless of the flag
+- Shape points are sorted by sequence
+- mGTFS round-trip preserves shape data
+"""
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+
+import pytest
+import railroaded as rr
+
+
+PATCO_URI   = (
+    'https://rapid.nationalrtap.org'
+    '/GTFSFileManagement/UserUploadFiles/13562/PATCO_GTFS.zip'
+)
+PATCO_CACHE_NO_SHAPES = os.path.join(os.path.dirname(__file__), 'patco_cache.json')
+PATCO_CACHE_WITH_SHAPES = os.path.join(os.path.dirname(__file__), 'patco_shapes_cache.json')
+
+
+@pytest.fixture(scope='session')
+def patco_no_shapes() -> rr.GTFS:
+    """PATCO feed loaded WITHOUT shapes (default)."""
+    return rr.GTFS.read(
+        name='PATCO',
+        gtfs_uri=PATCO_URI,
+        mgtfs_path=PATCO_CACHE_NO_SHAPES,
+        shapes=False,
+    )
+
+
+@pytest.fixture(scope='session')
+def patco_with_shapes() -> rr.GTFS:
+    """PATCO feed loaded WITH shapes."""
+    return rr.GTFS.read(
+        name='PATCO',
+        gtfs_uri=PATCO_URI,
+        mgtfs_path=PATCO_CACHE_WITH_SHAPES,
+        shapes=True,
+    )
+
+
+class TestShapesDefault:
+    """shapes=False (default) should produce an empty Shapes table."""
+
+    def test_shapes_table_exists(self, patco_no_shapes: rr.GTFS) -> None:
+        assert hasattr(patco_no_shapes, 'shapes')
+
+    def test_shapes_table_empty(self, patco_no_shapes: rr.GTFS) -> None:
+        assert len(patco_no_shapes.shapes.ids) == 0
+
+    def test_other_tables_unaffected(self, patco_no_shapes: rr.GTFS) -> None:
+        assert len(patco_no_shapes.trips.ids) > 0
+        assert len(patco_no_shapes.stops.ids) > 0
+
+
+class TestShapesLoaded:
+    """shapes=True should load shape geometry from shapes.txt."""
+
+    def test_shapes_table_populated(self, patco_with_shapes: rr.GTFS) -> None:
+        assert len(patco_with_shapes.shapes.ids) > 0
+
+    def test_shape_has_points(self, patco_with_shapes: rr.GTFS) -> None:
+        shape = patco_with_shapes.shapes.shapes[0]
+        assert len(shape.points) > 0
+
+    def test_shape_points_have_coords(self, patco_with_shapes: rr.GTFS) -> None:
+        shape = patco_with_shapes.shapes.shapes[0]
+        pt = shape.points[0]
+        assert pt.lat is not None
+        assert pt.lon is not None
+        assert -90 <= pt.lat <= 90
+        assert -180 <= pt.lon <= 180
+
+    def test_shape_points_sorted_by_sequence(self, patco_with_shapes: rr.GTFS) -> None:
+        for shape in patco_with_shapes.shapes.shapes:
+            seqs = [p.sequence for p in shape.points]
+            assert seqs == sorted(seqs), f'Shape {shape.id} not sorted'
+
+    def test_trip_shape_ids_reference_valid_shapes(self, patco_with_shapes: rr.GTFS) -> None:
+        shape_ids = set(patco_with_shapes.shapes.ids)
+        for trip in patco_with_shapes.trips.trips:
+            if trip.shape_id:
+                assert trip.shape_id in shape_ids, \
+                    f'Trip {trip.id} references missing shape {trip.shape_id}'
+
+    def test_shape_lookup_by_id(self, patco_with_shapes: rr.GTFS) -> None:
+        sid = patco_with_shapes.shapes.ids[0]
+        shape = patco_with_shapes.shapes[sid]
+        assert shape is not None
+        assert shape.id == sid
+
+    def test_shape_lookup_missing_returns_none(self, patco_with_shapes: rr.GTFS) -> None:
+        assert patco_with_shapes.shapes['__nonexistent__'] is None
+
+    def test_other_tables_unaffected(self, patco_with_shapes: rr.GTFS) -> None:
+        assert len(patco_with_shapes.trips.ids) > 0
+        assert len(patco_with_shapes.stops.ids) > 0
+
+
+class TestShapesSerialization:
+    """Shapes should survive mGTFS JSON round-trip."""
+
+    def test_round_trip_preserves_shapes(self, patco_with_shapes: rr.GTFS) -> None:
+        with tempfile.NamedTemporaryFile(suffix='.json', delete=False, mode='w') as f:
+            tmp_path = f.name
+        try:
+            rr.GTFS.save(patco_with_shapes, tmp_path)
+            reloaded = rr.GTFS.read(name='PATCO', mgtfs_path=tmp_path)
+            assert len(reloaded.shapes.ids) == len(patco_with_shapes.shapes.ids)
+            # Spot-check one shape
+            sid = patco_with_shapes.shapes.ids[0]
+            orig = patco_with_shapes.shapes[sid]
+            copy = reloaded.shapes[sid]
+            assert len(copy.points) == len(orig.points)
+            assert copy.points[0].lat == pytest.approx(orig.points[0].lat)
+            assert copy.points[0].lon == pytest.approx(orig.points[0].lon)
+        finally:
+            os.unlink(tmp_path)
+
+    def test_no_shapes_key_in_default_cache(self) -> None:
+        """mGTFS saved with shapes=False should have an empty shapes data dict."""
+        if os.path.exists(PATCO_CACHE_NO_SHAPES):
+            with open(PATCO_CACHE_NO_SHAPES) as f:
+                data = json.load(f)
+            shapes_data = data.get('shapes', {}).get('data', {})
+            assert len(shapes_data) == 0
+
+
+class TestBackwardCompatibility:
+    """Existing mGTFS files without a shapes key should load cleanly."""
+
+    def test_load_legacy_cache_without_shapes_key(self) -> None:
+        """Simulate loading a pre-shapes mGTFS file."""
+        legacy = {
+            'name': 'TEST',
+            'agencies': {'data': {}},
+            'routes': {'data': {}},
+            'schedules': {'data': {}},
+            'stops': {'data': {}},
+            'trips': {'data': {}},
+            # No 'shapes' key at all — simulating a pre-0.3.0 cache
+        }
+        with tempfile.NamedTemporaryFile(suffix='.json', delete=False, mode='w') as f:
+            json.dump(legacy, f)
+            tmp_path = f.name
+        try:
+            gtfs = rr.GTFS.read(name='TEST', mgtfs_path=tmp_path)
+            # shapes may be None (key absent) or an empty Shapes table
+            assert gtfs.shapes is None or len(gtfs.shapes.ids) == 0
+            assert gtfs.name == 'TEST'
+        finally:
+            os.unlink(tmp_path)

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "railroaded",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "a minimal GTFS parsing and processing utility",
   "main": "index.ts",
   "repository": "https://www.github.com/bwiswell/railroaded/typescript",


### PR DESCRIPTION
Add ShapePoint model, Shape model, and Shapes table for GTFS shapes.txt polyline geometry. Loading is opt-in via a new shapes=True parameter on GTFS.read() — default is False to keep railroaded lightweight for consumers that don't need geometry data.

New files:
  models/shape_point.py  — single lat/lon/sequence point
  models/shape.py        — ordered polyline of ShapePoints
  tables/shapes.py       — keyed dict with from_gtfs()
  tests/test_shapes.py   — 14 tests (opt-in, serialization,
                           backward compat with pre-0.3.0 caches)

Backward compatible: existing mGTFS caches without a shapes key load with an empty Shapes table. Feeds lacking shapes.txt also produce an empty table regardless of the flag.